### PR TITLE
Remove consult--jump-state argument

### DIFF
--- a/consult-flycheck.el
+++ b/consult-flycheck.el
@@ -106,7 +106,7 @@ In contrast to `flycheck-error-level-<' sort errors first."
    :group (consult--type-group consult-flycheck--narrow)
    :narrow (consult--type-narrow consult-flycheck--narrow)
    :lookup #'consult--lookup-candidate
-   :state (consult--jump-state 'consult-preview-error)))
+   :state (consult--jump-state)))
 
 (provide 'consult-flycheck)
 ;;; consult-flycheck.el ends here


### PR DESCRIPTION
`consult--jump-state` takes no argument since https://github.com/minad/consult/commit/1343e39fefcf8a28a7a415aa4b0a8ff7094370bf